### PR TITLE
Fix exportNodeAsImage format option

### DIFF
--- a/src/cursor_mcp_plugin/code.js
+++ b/src/cursor_mcp_plugin/code.js
@@ -1190,9 +1190,7 @@ async function createComponentInstance(params) {
 }
 
 async function exportNodeAsImage(params) {
-  const { nodeId, scale = 1 } = params || {};
-
-  const format = "PNG";
+  const { nodeId, format = "PNG", scale = 1 } = params || {};
 
   if (!nodeId) {
     throw new Error("Missing nodeId parameter");


### PR DESCRIPTION
## Summary
- allow `exportNodeAsImage` to accept the `format` parameter

## Testing
- `bun run build`
- `bun run start` *(fails to connect to Figma socket)*

------
https://chatgpt.com/codex/tasks/task_e_684ff16fa1108328872cb4404771c729